### PR TITLE
bug: Fix build error by adding @c6o/ui-theme to istio dependencies

### DIFF
--- a/packages/istio/package.json
+++ b/packages/istio/package.json
@@ -38,6 +38,7 @@
   "homepage": "https://github.com/c6o/provisioners#readme",
   "dependencies": {
     "@c6o/kubeclient": "^0.0.5",
+    "@c6o/ui-theme": "^0.0.3",
     "@provisioner/common": "^0.0.4",
     "lit-element": "^2.3.1",
     "mixwith": "^0.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -859,6 +859,16 @@
     ts-try "^0.2.0"
     ulid "^2.3.0"
 
+"@c6o/ui-theme@^0.0.3":
+  version "0.0.3"
+  resolved "http://develop.npm.codezero.io/@c6o%2fui-theme/-/ui-theme-0.0.3.tgz#339fb38a56c0293c4d02536d36fbcff469d4d028"
+  integrity sha512-g4pOfyp61YLb098npewx/WHK/HkXSUqwoK+6IzgwYQ6bYhrTC+IBQw6duZCf1pnhkwYfOD1xZKfgO0eD1I6rkw==
+  dependencies:
+    lit-element "^2.3.1"
+    source-map-support "^0.5.16"
+    typeface-montserrat "^0.0.75"
+    typeface-roboto "^0.0.75"
+
 "@evocateur/libnpmaccess@^3.1.2":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@evocateur/libnpmaccess/-/libnpmaccess-3.1.2.tgz#ecf7f6ce6b004e9f942b098d92200be4a4b1c845"
@@ -8841,6 +8851,16 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typeface-montserrat@^0.0.75:
+  version "0.0.75"
+  resolved "http://develop.npm.codezero.io/typeface-montserrat/-/typeface-montserrat-0.0.75.tgz#b796d9c767ab8ed1343271985beb1e44b382b7b3"
+  integrity sha512-8ski20t3hdwu2T85pVfjK4jsDbwW8yWzd+LAKxYEmu+JVLVlB7G2yfmdKZz06pUwYCLVFvHvup+NYYulHDpE+w==
+
+typeface-roboto@^0.0.75:
+  version "0.0.75"
+  resolved "http://develop.npm.codezero.io/typeface-roboto/-/typeface-roboto-0.0.75.tgz#98d5ba35ec234bbc7172374c8297277099cc712b"
+  integrity sha512-VrR/IiH00Z1tFP4vDGfwZ1esNqTiDMchBEXYY9kilT6wRGgFoCAlgkEUMHb1E3mB0FsfZhv756IF0+R+SFPfdg==
 
 typescript@^3.9.5:
   version "3.9.6"


### PR DESCRIPTION
Fix isto build error ( #22) when trying to build from provisioners repository root (ie: not through monorepo).