### PR TITLE
Fix UI storage property name to match expected spec

### DIFF
--- a/packages/suitecrm/c6o/app.yaml
+++ b/packages/suitecrm/c6o/app.yaml
@@ -6,13 +6,12 @@ editions:
   - name: stable
     status: public
     spec:
-    routes:
-      - type: http
-        targetService: suitecrm
-    provisioner:
-      package: "@provisioner/suitecrm"
-      ui: ignore
-    marina:
-      launch:
-      type: inline
-      popUp: true
+      routes:
+        - type: http
+          targetService: suitecrm
+      provisioner:
+        package: "@provisioner/suitecrm"
+      marina:
+        launch:
+          type: inline
+          popUp: true

--- a/packages/suitecrm/src/ui/index.ts
+++ b/packages/suitecrm/src/ui/index.ts
@@ -19,19 +19,19 @@ export class SuiteCRMSettings extends LitElement implements StoreFlowStep {
                 <c6o-password-field @input=${this.passwordChanged} label="Administrator password" value=${this.serviceSpec.suitecrmpassword} autoselect required></c6o-password-field>
             </c6o-form-layout>
             <c6o-form-layout>
-                <c6o-combo-box @selected-item-changed=${this.storageSelected} label="Database Storage" value=${this.serviceSpec.storage} required allow-custom-value .items=${this.storageSizeChoices}></c6o-combo-box>
+                <c6o-combo-box @selected-item-changed=${this.storageSelected} label="Database Storage" value=${this.serviceSpec.databasesize} required allow-custom-value .items=${this.storageSizeChoices}></c6o-combo-box>
             </c6o-form-layout>
         `
     }
 
     async begin() {
-        this.serviceSpec.storage = this.serviceSpec.storage || '1Gi'
+        this.serviceSpec.databasesize = this.serviceSpec.databasesize || '1Gi'
         this.serviceSpec.suitecrmusername = this.serviceSpec.suitecrmusername || 'admin'
         this.serviceSpec.suitecrmpassword = this.serviceSpec.suitecrmpassword || 'admin'
     }
 
     storageSelected = (e) => {
-        this.serviceSpec.storage = e.detail.value
+        this.serviceSpec.databasesize = e.detail.value
     }
 
     usernameChanged = (e) => {


### PR DESCRIPTION
## Description
SuiteCRM install fails from web UI.  This is because the "`databasesize`" property is never set by the UI (it instead uses the property name "`storage`").

Fixes #103 

![image](https://user-images.githubusercontent.com/4723264/100499183-5764c800-311c-11eb-89ac-8279a4ef69b4.png)

![image](https://user-images.githubusercontent.com/4723264/100499194-677ca780-311c-11eb-959b-8a5ccd8aee42.png)


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
