### PR TITLE
Added c6o-system modify files based on environments.

### DIFF
--- a/packages/c6o-system/c6o/app-develop.yaml
+++ b/packages/c6o-system/c6o/app-develop.yaml
@@ -1,0 +1,4 @@
+editions:
+  - spec:
+      provisioner:
+        tag: dragon

--- a/packages/c6o-system/c6o/app-staging.yaml
+++ b/packages/c6o-system/c6o/app-staging.yaml
@@ -1,0 +1,4 @@
+editions:
+  - spec:
+      provisioner:
+        tag: canary


### PR DESCRIPTION
We have had problems with latest tags being deployed to staging or develop. What we want is when the system provisioner is deployed, that the edition tag be updated to either canary or dragon based on the environment staging or develop.

Modify the czctl publish command to merge an environmentally specific subset of tags into the main file.