### PR TITLE
feat(SuiteCRM): Add OXD service to SuiteCRM to support OIDC

### DIFF
--- a/packages/suitecrm/c6o/app.yaml
+++ b/packages/suitecrm/c6o/app.yaml
@@ -52,3 +52,16 @@ editions:
         launch:
           type: inline
           popUp: true
+  - name: preview with oxd
+    status: public
+    spec:
+      routes:
+      - type: http
+        targetService: suitecrm
+      provisioner:
+        package: '@conneryn/suitecrm-with-oxd'
+        includeOxd: true
+      marina:
+        launch:
+          type: inline
+          popUp: true

--- a/packages/suitecrm/k8s/latest/6-deployment.yaml
+++ b/packages/suitecrm/k8s/latest/6-deployment.yaml
@@ -23,6 +23,11 @@ spec:
         hostnames:
         - "status.localhost"
       containers:
+{{#if includeOxd}}
+      - name: oxd
+        image: conneryn/oxd-3.1.4:latest
+        imagePullPolicy: "IfNotPresent"
+{{/if}}
       - name: suitecrm
         image: docker.io/bitnami/suitecrm:7.11.13-debian-10-r27
         imagePullPolicy: "IfNotPresent"

--- a/packages/suitecrm/oxd/Dockerfile
+++ b/packages/suitecrm/oxd/Dockerfile
@@ -1,0 +1,14 @@
+FROM openjdk:8-jre
+
+WORKDIR /opt/oxd/
+
+RUN wget http://ox.gluu.org/maven/org/xdi/oxd-server/3.1.4.Final/oxd-server-3.1.4.Final-distribution.zip
+RUN unzip oxd-server-3.1.4.Final-distribution.zip
+RUN chmod +x bin/oxd-start.sh
+
+COPY oxd-conf.json /etc/oxd/oxd-server/oxd-conf.json
+
+EXPOSE 8099 8099
+
+CMD ["bin/oxd-start.sh"]
+

--- a/packages/suitecrm/oxd/README.md
+++ b/packages/suitecrm/oxd/README.md
@@ -1,0 +1,15 @@
+# OXD Docker Image
+
+SuiteCRM's OIDC module depends on a running service called OXD.  This dockerfile runs a basic instance of OXD on version 3.1.4.
+
+See links below for more details:
+
+1. https://github.com/GluuFederation/suitecrm-oxd-module
+1. https://gluu.org/docs/oxd/3.1.4/plugin/suitecrm/
+
+## To Build
+
+```bash
+docker build -t c6oio/oxd-server-3.1.4
+docker push c6oio/oxd-server-3.1.4
+```

--- a/packages/suitecrm/oxd/oxd-conf.json
+++ b/packages/suitecrm/oxd/oxd-conf.json
@@ -1,0 +1,24 @@
+{
+    "port":8099,
+    "localhost_only":true,
+    "time_out_in_seconds":0,
+    "use_client_authentication_for_pat":true,
+    "trust_all_certs":true,
+    "trust_store_path":"",
+    "trust_store_password":"",
+    "crypt_provider_key_store_path":"",
+    "crypt_provider_key_store_password":"",
+    "crypt_provider_dn_name":"",
+    "support-google-logout":true,
+    "state_expiration_in_minutes":5,
+    "nonce_expiration_in_minutes":5,
+    "public_op_key_cache_expiration_in_minutes":60,
+    "protect_commands_with_access_token":false,
+    "uma2_auto_register_claims_gathering_endpoint_as_redirect_uri_of_client":true,
+    "migration_source_folder_path":"",
+    "storage":"h2",
+    "storage_configuration": {
+        "dbFileLocation":"/opt/oxd-server/data/oxd_db"
+    },
+    "remove_expired_clients":true
+}

--- a/packages/suitecrm/src/mixins/createApply.ts
+++ b/packages/suitecrm/src/mixins/createApply.ts
@@ -29,6 +29,8 @@ export const createApplyMixin = (base: baseProvisionerType) => class extends bas
             suitecrmusername,
             suitecrmpassword,
             databasesize,
+
+            includeOxd,
         } = this.spec
 
         const username = Buffer.from(suitecrmusername).toString('base64')
@@ -70,7 +72,7 @@ export const createApplyMixin = (base: baseProvisionerType) => class extends bas
         await this.manager.cluster
             .begin('Install SuiteCRM Deployment')
             .addOwner(this.manager.document)
-            .upsertFile('../../k8s/latest/6-deployment.yaml', { namespace, includeOxd: true })
+            .upsertFile('../../k8s/latest/6-deployment.yaml', { namespace, includeOxd })
             .end()
 
 

--- a/packages/suitecrm/src/mixins/createApply.ts
+++ b/packages/suitecrm/src/mixins/createApply.ts
@@ -70,7 +70,7 @@ export const createApplyMixin = (base: baseProvisionerType) => class extends bas
         await this.manager.cluster
             .begin('Install SuiteCRM Deployment')
             .addOwner(this.manager.document)
-            .upsertFile('../../k8s/latest/6-deployment.yaml', { namespace })
+            .upsertFile('../../k8s/latest/6-deployment.yaml', { namespace, includeOxd: true })
             .end()
 
 


### PR DESCRIPTION
## Description

In order to enable OIDC on SuiteCRM, a local service called OXD must be running.  This PR adds a second Edition to the SuiteCRM provisioner called 'preview with oxd'.   When this edition is installed a second container (running OXD) is added to the same pod as SuiteCRM.

Fixes #159 

NOTE: there was no official Docker image for OXD version 3.1.4 (required by SuiteCRM), so I have included a basic Dockerfile used to create a custom image (currently [conneryn/oxd-3.1.4](https://hub.docker.com/r/conneryn/oxd-3.1.4)).   There is no automation around the generation/publishing of this image.   However, because OXD 3.1.x has not changed in several years, I feel it is unlikely this will ever need to be re-built/published and so I am including the Dockerfile primary for the purpose of transparency, rather than continued development.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
