### PR TITLE
fix: Configs and Secrets cannot be an array, must be KeyValue

### DIFF
--- a/packages/cachet/c6o.yaml
+++ b/packages/cachet/c6o.yaml
@@ -93,9 +93,9 @@ editions:
 
 
         configs:
-          - POSTGRES_PORT: 5432
-          - APP_KEY: base64:04o0jBc+4hSNrJNS39i8J6185ubrC/YtOMwHGhw8v6o=
-          - DB_DRIVER: pgsql
+          POSTGRES_PORT: 5432
+          APP_KEY: base64:04o0jBc+4hSNrJNS39i8J6185ubrC/YtOMwHGhw8v6o=
+          DB_DRIVER: pgsql
 
       marina:
         launch:

--- a/packages/cassandra-web/c6o.yaml
+++ b/packages/cassandra-web/c6o.yaml
@@ -75,8 +75,8 @@ editions:
 
 
         configs:
-          - HOST_PORT: ":80"
-          - CASSANDRA_PORT: 9042
+          HOST_PORT: ":80"
+          CASSANDRA_PORT: "9042"
 
       marina:
         launch:

--- a/packages/codeserver/c6o.yaml
+++ b/packages/codeserver/c6o.yaml
@@ -107,9 +107,9 @@ editions:
           #   autoselect: true
           #   fieldType: password
 
-          - SUDO_PASSWORD:
-              generate:
-                length: 32
+          SUDO_PASSWORD:
+            generate:
+              length: 32
       marina:
         launch:
           type: inline

--- a/packages/etherpad/c6o.yaml
+++ b/packages/etherpad/c6o.yaml
@@ -35,12 +35,12 @@ editions:
         ports: 9001
 
         secrets:
-          - ADMIN_PASSWORD:
-              generate:
-                length: 32
+          ADMIN_PASSWORD:
+            generate:
+              length: 32
 
-        config:
-          - TRUST_PROXY: true
+        configs:
+          TRUST_PROXY: true
 
       marina:
         launch:

--- a/packages/filerun/c6o.yaml
+++ b/packages/filerun/c6o.yaml
@@ -164,12 +164,12 @@ editions:
                 required: true
 
         configs:
-          - FR_DB_PORT: 3306
-          - FR_DB_NAME: filerun
-          - APACHE_RUN_USER: www-data
-          - APACHE_RUN_USER_ID: 33
-          - APACHE_RUN_GROUP: www-data
-          - APACHE_RUN_GROUP_ID: 33
+          FR_DB_PORT: 3306
+          FR_DB_NAME: filerun
+          APACHE_RUN_USER: www-data
+          APACHE_RUN_USER_ID: 33
+          APACHE_RUN_GROUP: www-data
+          APACHE_RUN_GROUP_ID: 33
 
       marina:
         launch:

--- a/packages/firefly-iii/c6o.yaml
+++ b/packages/firefly-iii/c6o.yaml
@@ -107,16 +107,16 @@ editions:
                 required: true
 
         configs:
-          - APP_ENV: local
-          - DB_PORT: "3306"
-          - DB_CONNECTION: mysql
-          - DB_DATABASE: firefly
-          - TRUSTED_PROXIES: '**'
+          APP_ENV: local
+          DB_PORT: "3306"
+          DB_CONNECTION: mysql
+          DB_DATABASE: firefly
+          TRUSTED_PROXIES: '**'
 
         secrets:
-          - APP_KEY:
-              generate:
-                length: 16
+          APP_KEY:
+            generate:
+              length: 16
       marina:
         launch:
           type: inline

--- a/packages/jupyter/c6o.yaml
+++ b/packages/jupyter/c6o.yaml
@@ -45,7 +45,7 @@ editions:
             mountPath: /home/jovyan/work
             name: jupyter-work
         configs:
-          - JUPYTER_ENABLE_LAB: yes
+          JUPYTER_ENABLE_LAB: yes
 
       marina:
         launch:
@@ -68,7 +68,7 @@ editions:
             mountPath: /home/jovyan/work
             name: jupyter-work
         configs:
-          - JUPYTER_ENABLE_LAB: yes
+          JUPYTER_ENABLE_LAB: yes
 
       marina:
         launch:
@@ -92,7 +92,7 @@ editions:
             mountPath: /home/jovyan/work
             name: jupyter-work
         configs:
-          - JUPYTER_ENABLE_LAB: yes
+          JUPYTER_ENABLE_LAB: yes
 
       marina:
         launch:
@@ -115,7 +115,7 @@ editions:
             mountPath: /home/jovyan/work
             name: jupyter-work
         configs:
-          - JUPYTER_ENABLE_LAB: yes
+          JUPYTER_ENABLE_LAB: yes
 
       marina:
         launch:
@@ -139,7 +139,7 @@ editions:
             mountPath: /home/jovyan/work
             name: jupyter-work
         configs:
-          - JUPYTER_ENABLE_LAB: yes
+          JUPYTER_ENABLE_LAB: yes
 
       marina:
         launch:
@@ -163,7 +163,7 @@ editions:
             mountPath: /home/jovyan/work
             name: jupyter-work
         configs:
-          - JUPYTER_ENABLE_LAB: yes
+          JUPYTER_ENABLE_LAB: yes
 
       marina:
         launch:
@@ -187,7 +187,7 @@ editions:
             mountPath: /home/jovyan/work
             name: jupyter-work
         configs:
-          - JUPYTER_ENABLE_LAB: yes
+          JUPYTER_ENABLE_LAB: yes
 
       marina:
         launch:
@@ -211,7 +211,7 @@ editions:
             mountPath: /home/jovyan/work
             name: jupyter-work
         configs:
-          - JUPYTER_ENABLE_LAB: yes
+          JUPYTER_ENABLE_LAB: yes
 
       marina:
         launch:
@@ -235,7 +235,7 @@ editions:
             mountPath: /home/jovyan/work
             name: jupyter-work
         configs:
-          - JUPYTER_ENABLE_LAB: yes
+          JUPYTER_ENABLE_LAB: yes
 
       marina:
         launch:
@@ -260,7 +260,7 @@ editions:
             mountPath: /home/jovyan/work
             name: jupyter-work
         configs:
-          - JUPYTER_ENABLE_LAB: yes
+          JUPYTER_ENABLE_LAB: yes
       marina:
         launch:
           type: inline

--- a/packages/mautic/c6o.yaml
+++ b/packages/mautic/c6o.yaml
@@ -107,8 +107,8 @@ editions:
                 required: true
 
         configs:
-          - MAUTIC_RUN_CRON_JOBS: true
-          - MAUTIC_TRUSTED_PROXIES: 0.0.0.0/0
+          MAUTIC_RUN_CRON_JOBS: true
+          MAUTIC_TRUSTED_PROXIES: 0.0.0.0/0
 
       marina:
         launch:

--- a/packages/moodle/c6o.yaml
+++ b/packages/moodle/c6o.yaml
@@ -132,7 +132,7 @@ editions:
                 required: true
 
         configs:
-            - ALLOW_EMPTY_PASSWORD: no
+          ALLOW_EMPTY_PASSWORD: no
 
         volumes:
             - size: 5Gi

--- a/packages/next-cloud/c6o.yaml
+++ b/packages/next-cloud/c6o.yaml
@@ -120,7 +120,7 @@ editions:
                 required: true
 
         configs:
-          - NEXTCLOUD_TRUSTED_DOMAINS: $PUBLIC_DNS
+          NEXTCLOUD_TRUSTED_DOMAINS: $PUBLIC_DNS
 
         volumes:
           - name: nextcloud-file-data

--- a/packages/objectdetection/c6o.yaml
+++ b/packages/objectdetection/c6o.yaml
@@ -40,9 +40,9 @@ editions:
             port: 8888
         tag-prefix: appengine
         configs:
-          - port: 5000
-          - host: 0.0.0.0
-          - debug: true
+          port: 5000
+          host: 0.0.0.0
+          debug: true
 
       marina:
         launch:

--- a/packages/redis/c6o.yaml
+++ b/packages/redis/c6o.yaml
@@ -60,7 +60,7 @@ editions:
         tag-prefix: appengine
         image: redis
         configs:
-          - appendonly: yes
+          appendonly: yes
         ports:
           - port: 6379
             name: tcp

--- a/packages/restyaboard/c6o.yaml
+++ b/packages/restyaboard/c6o.yaml
@@ -112,7 +112,7 @@ editions:
                 target: secrets
 
         configs:
-          - POSTGRES_PORT : 5432
+          POSTGRES_PORT : 5432
 
       marina:
         launch:

--- a/packages/splunk/c6o.yaml
+++ b/packages/splunk/c6o.yaml
@@ -55,7 +55,7 @@ editions:
                 target: secrets
 
         configs:
-          - SPLUNK_START_ARGS: "--accept-license"
+          SPLUNK_START_ARGS: --accept-license
 
 
       marina:


### PR DESCRIPTION
## Description

When configs are configured as an array, the ConfigMap fails to apply with the error:
```
Error: ConfigMap in version "v1" cannot be handled as a ConfigMap: v1.ConfigMap.Data: ReadMapCB: expect { or n, but found [, error fo  und in #10 byte of ...|},"data":[{"SPLUNK_S|..., bigger context ...|ade0cd03441","blockOwnerDeletion":true}]},"data":[{"SPLUNK_START_  ARGS":"--accept-license"}]}|...
```

This is because it is uploading as an array:
```
{
  apiVersion: 'v1',
  kind: 'ConfigMap',
  metadata: {
    name: 'splunk-config',
    namespace: 'testing',
    labels: {
      app: 'splunk',
      name: 'splunk',
      'system.codezero.io/appengine': '1.0',
      'system.codezero.io/app': 'splunk',
      'system.codezero.io/id': 'testing-splunk',
      'system.codezero.io/edition': 'local',
      'app.kubernetes.io/name': 'splunk',
      'app.kubernetes.io/managed-by': 'codezero'
    }
  },
  data: [ { SPLUNK_START_ARGS: '--accept-license' } ]
}
```

## Type of change
