### PR TITLE
fix: AppEngine fails on ConfigMap with boolean or numeric values

### DIFF
--- a/packages/appengine/src/mixins/createApply.ts
+++ b/packages/appengine/src/mixins/createApply.ts
@@ -90,10 +90,16 @@ export const createApplyMixin = (base: baseProvisionerType) => class extends bas
                 return
             }
 
+            const configs = {}
+            for(const key of Object.keys(this.manifestHelper.configs)) {
+                // Must be string, even if originally a boolean or number.
+                configs[key] = String(this.manifestHelper.configs[key])
+            }
+
             const createConfigMap = templates.getConfigTemplate(
                 this.manifestHelper.name,
                 this.manifestHelper.namespace,
-                this.manifestHelper.configs as keyValue,
+                configs,
                 this.manifestHelper.getComponentLabels()
             )
 


### PR DESCRIPTION
## Description
Kubernetes [ConfigMap ](https://kubernetes.io/docs/concepts/configuration/configmap/) `data` MUST be a keyvalue pair of strings.  We fail to apply ConfigMaps if they contain boolean or numeric values.

Example error installing NodeRed:
```
v1.ConfigMap.Data: ReadString: expects " or n, but found t, error found in #10 byte of ...|ROJECTS":true,"TZ":"|..., bigger   context ...|ined","1":"undefined","NODE_RED_ENABLE_PROJECTS":true,"TZ":"America/New_York"},"kind":"ConfigMap","m|...
```

This change was specifically tested to fix the NodeRED installation.