### PR TITLE
fix(nodered): add fsGroup to AppEngine deployments to fix volume permission error

### DIFF
--- a/packages/appengine/src/templates/deployment.ts
+++ b/packages/appengine/src/templates/deployment.ts
@@ -38,6 +38,10 @@ export function getDeploymentTemplate(
                     labels
                 },
                 spec: {
+                    securityContext: {
+                        // See https://github.com/c6o/provisioners/issues/182
+                        fsGroup: 1000,
+                    },
                     containers: [{
                         name,
                         image,


### PR DESCRIPTION
## Description

Broad but effective solution to volume permission errors when running an application is running as normal user (non-root).  See #182 for more details.

Fixes #182 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] NodeRED succesfully installs and is accessible after running `czctl install --local ./packages/nodered/c6o.yaml`