### PR TITLE
Minor fixes to Wordpress, Strapi, and Seq provisioners

### DIFF
--- a/packages/seq/c6o.yaml
+++ b/packages/seq/c6o.yaml
@@ -35,7 +35,7 @@ editions:
     spec:
       routes:
         - type: http
-          targetService: seq
+          targetService: seq-logging
       provisioner:
         package: '@provisioner/appengine'
         tag-prefix: appengine
@@ -43,13 +43,15 @@ editions:
         ports: 80
         flow:
           prompts:
-              - type: confirm
+              - type: input
                 name: ACCEPT_EULA
                 message: Accept EULA
-                default: true
+                default: Y
+                validate: return value === 'Y' || 'You must accept the EULA (please enter \'Y\')'
                 c6o:
                   label: Accept EULA
+                  required: true
+
       marina:
         launch:
           type: inline
-          popUp: true

--- a/packages/strapi/c6o.yaml
+++ b/packages/strapi/c6o.yaml
@@ -173,55 +173,21 @@ editions:
             mountPath: /srv/app
             size: 50Gi
 
-        flow:
-          prompts:
-            - type: input
-              name: DATABASE_HOST
-              message: The name of the database server (Service)
-              default: mariadb.database
-              required: true
-              c6o:
-                label: Database Host
+        configs:
+          DATABASE_CLIENT: mongo
+          DATABASE_PORT: 27017
+          DATABASE_HOST: mongo-svc
+          DATABASE_NAME: strapi
+          DATABASE_USERNAME: root
+          DATABASE_SSL: false
+          DATABASE_AUTHENTICATION_DATABASE: admin
 
-            - type: number
-              name: DATABASE_PORT
-              message: The port of the database server (Service)
-              default: 27017
-              required: true
-              c6o:
-                label: Database Host Port
+        services:
+          - mongo:
+              rootPasswordKey: DATABASE_PASSWORD
 
-            - type: input
-              name: DATABASE_CLIENT
-              message: Database Client Driver
-              default: mongo
-              required: true
-              c6o:
-                label: Database Client Driver
-
-            - type: input
-              name: DATABASE_NAME
-              message: The name of the database to use
-              default: strapi
-              required: true
-              c6o:
-                label: Database Name
-
-            - type: input
-              name: DATABASE_USERNAME
-              message: The username for the database user
-              default: strapi
-              required: true
-              c6o:
-                label: Database user name
-
-            - type: password
-              name: DATABASE_PASSWORD
-              message: The password for the database user
-              default: strapi
-              required: true
-              c6o:
-                label: Database password
+        secretRefs:
+          - mongo-root
 
       marina:
         launch:

--- a/packages/strapi/c6o.yaml
+++ b/packages/strapi/c6o.yaml
@@ -70,13 +70,14 @@ editions:
               - type: startup
                 periodSeconds: 10
                 initialDelaySeconds: 60
+      marina:
         launch:
           type: inline
           popUp: true
 
 
   - name: latest-postgresql
-    status: public
+    status: private
     spec:
       routes:
         - type: http
@@ -97,51 +98,47 @@ editions:
         volumes:
           - name: yarn-cache
             mountPath: /usr/local/share/.cache/
-            size: 50Gi
+            size: 1Gi
           - name: strapi-data
             mountPath: /srv/app
             size: 50Gi
-        config:
+        flow:
+          prompts:
+            - type: input
+              name: DATABASE_HOST
+              message: Specify the host name of your database server service (postgres)
+              default: postgres
+              c6o:
+                label: Database Host
+                required: true
 
-          - name: DATABASE_HOST
-            label: Database Host
-            hint: The name of the database server (Service)
-            required: true
-            autoselect: true
-            fieldType: text
-            value: strapi
+            - type: input
+              name: DATABASE_NAME
+              message: The name of the database to use
+              default: strapi
+              c6o:
+                label: Database Name
+                required: true
 
-          - name: DATABASE_PORT
-            value: 5432
+            - type: input
+              name: DATABASE_USERNAME
+              message: The username for the database user
+              default: strapi
+              c6o:
+                label: Database User
+                required: true
 
-          - name: DATABASE_CLIENT
-            value: postgres
+            - type: password
+              name: DATABASE_PASSWORD
+              message: The password for the database user
+              c6o:
+                target: secrets
+                label: Database Password
+                required: true
 
-          - name: DATABASE_NAME
-            label: Database Name
-            hint: The name of the database to use
-            required: true
-            autoselect: true
-            fieldType: text
-            value: strapi
-
-          - name: DATABASE_USERNAME
-            label: Database user name
-            hint: The username for the database user
-            required: true
-            autoselect: true
-            fieldType: text
-            value: strapi
-
-
-        secret:
-
-          - name: DATABASE_PASSWORD
-            label: Database password
-            hint: The password for the database user
-            required: true
-            autoselect: true
-            fieldType: password
+        configs:
+          DATABASE_PORT: 5432
+          DATABASE_CLIENT: postgres
 
       marina:
         launch:
@@ -150,7 +147,7 @@ editions:
 
 
   - name: latest-mongo
-    status: public
+    status: private
     spec:
       routes:
         - type: http
@@ -171,7 +168,7 @@ editions:
         volumes:
           - name: yarn-cache
             mountPath: /usr/local/share/.cache/
-            size: 50Gi
+            size: 1Gi
           - name: strapi-data
             mountPath: /srv/app
             size: 50Gi

--- a/packages/wordpress/k8s/latest/4-service.yaml
+++ b/packages/wordpress/k8s/latest/4-service.yaml
@@ -1,4 +1,4 @@
-mongoapiVersion: v1
+apiVersion: v1
 kind: Service
 metadata:
   namespace: {{namespace}}


### PR DESCRIPTION
## Description

Minor fixes to Wordpress, Strapi, and Seq. 

Strapi's mongo and postgres editions have been marked private because they still fail.
See issue: https://github.com/c6o/provisioners/issues/193