### PR TITLE
feat(HelmEngine): Initial commit of HelmEngine provisioner

### DIFF
--- a/packages/helmengine/LICENSE
+++ b/packages/helmengine/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/helmengine/c6o/discourse.yaml
+++ b/packages/helmengine/c6o/discourse.yaml
@@ -1,0 +1,45 @@
+name: Discourse
+appId: discourse
+
+editions:
+  - name: stable
+    status: public
+    spec:
+      routes:
+        - type: http
+          targetService: discourse
+      provisioner:
+        package: '@provisioner/helmengine'
+        tag-prefix: helmengine
+
+        image: dummyvalue
+        chart: discourse
+        repo: https://charts.bitnami.com/bitnami
+
+        flow:
+          prompts:
+          - type: input
+            name: discourse:username
+            message: Admin Username
+            c6o:
+              label: Admin Username
+              required: true
+          - type: password
+            name: discourse:password
+            message: Admin password
+            
+            c6o:
+              label: Admin password
+              required: true
+              target: secrets
+
+        configs:
+          service:
+            type: NodePort
+            port: 80
+          discourse:host: discourse--demo.cn-dev.codezero.dev  # Replace with $PUBLIC_FQDN when fixed
+
+      marina:
+        launch:
+          type: inline
+          popUp: true

--- a/packages/helmengine/c6o/discourse.yaml
+++ b/packages/helmengine/c6o/discourse.yaml
@@ -3,7 +3,7 @@ appId: discourse
 
 editions:
   - name: stable
-    status: public
+    status: private
     spec:
       routes:
         - type: http
@@ -37,7 +37,7 @@ editions:
           service:
             type: NodePort
             port: 80
-          discourse:host: discourse--demo.cn-dev.codezero.dev  # Replace with $PUBLIC_FQDN when fixed
+          discourse:host: $PUBLIC_FQDN
 
       marina:
         launch:

--- a/packages/helmengine/c6o/kubeapps.yaml
+++ b/packages/helmengine/c6o/kubeapps.yaml
@@ -1,0 +1,30 @@
+name: KubeApps
+appId: kubeapps
+
+editions:
+  - name: stable
+    status: public
+    spec:
+      routes:
+        - type: http
+          targetService: kubeapps
+      provisioner:
+        package: '@provisioner/helmengine'
+        tag-prefix: helmengine
+
+        image: dummyvalue
+        chart: kubeapps
+        repo: https://charts.bitnami.com/bitnami
+
+        clusterAdmin: true
+
+        configs:
+          allowNamespaceDiscovery: false
+          frontend:
+            service:
+              type: NodePort
+              port: 80
+      marina:
+        launch:
+          type: inline
+          popUp: true

--- a/packages/helmengine/c6o/kubeapps.yaml
+++ b/packages/helmengine/c6o/kubeapps.yaml
@@ -3,7 +3,7 @@ appId: kubeapps
 
 editions:
   - name: stable
-    status: public
+    status: private
     spec:
       routes:
         - type: http

--- a/packages/helmengine/c6o/wordpress.yaml
+++ b/packages/helmengine/c6o/wordpress.yaml
@@ -3,7 +3,7 @@ appId: helm-wp
 
 editions:
 - name: stable
-  status: public
+  status: private
   spec:
     routes:
     - type: http

--- a/packages/helmengine/c6o/wordpress.yaml
+++ b/packages/helmengine/c6o/wordpress.yaml
@@ -1,0 +1,42 @@
+name: Wordpress
+appId: helm-wp
+
+editions:
+- name: stable
+  status: public
+  spec:
+    routes:
+    - type: http
+      targetService: helm-wp-wordpress
+    provisioner:
+      package: '@provisioner/helmengine'
+      tag-prefix: helmengine
+
+      image: dummyvalue
+      chart: wordpress
+      repo: https://charts.bitnami.com/bitnami
+
+      flow:
+        prompts:
+        - type: input
+          name: wordpressUsername
+          message: Wordpress Username
+          c6o:
+            label: Wordpress Username
+            required: true
+        - type: password
+          name: wordpressPassword
+          message: Wordpress password
+          c6o:
+            label: Wordpress password
+            required: true
+            target: secrets
+
+      configs:
+        service:
+          type: NodePort
+          port: 8080
+    marina:
+      launch:
+        type: inline
+        popUp: true

--- a/packages/helmengine/jest.config.unit.js
+++ b/packages/helmengine/jest.config.unit.js
@@ -1,0 +1,21 @@
+//export default {
+module.exports = {
+    'roots': [
+        '<rootDir>/src'
+    ],
+    'testMatch': [
+        '**/?(*.)+(unit).+(ts)',
+    ],
+    'transform': {
+        '^.+\\.(ts|tsx)$': 'ts-jest',
+    },
+    'reporters': [
+        'default',
+        ['jest-html-reporters', {
+            'publicPath': './coverage',
+            'filename': 'report.html',
+            'expand': true,
+        }],
+    ],
+    setupFiles: ['<rootDir>/jestsetup.js'],
+}

--- a/packages/helmengine/jestsetup.js
+++ b/packages/helmengine/jestsetup.js
@@ -1,0 +1,3 @@
+process.on('unhandledRejection', (err) => {
+    fail(err);
+});

--- a/packages/helmengine/k8s/clusterServiceAccount.yaml
+++ b/packages/helmengine/k8s/clusterServiceAccount.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{serviceAccountName}}
+  namespace: {{namespace}}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+ name: {{serviceAccountName}}-cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: {{serviceAccountName}}
+  namespace: {{namespace}}
+roleRef:
+ kind: ClusterRole
+ name: cluster-admin
+ apiGroup: rbac.authorization.k8s.io

--- a/packages/helmengine/k8s/serviceAccount.yaml
+++ b/packages/helmengine/k8s/serviceAccount.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{serviceAccountName}}
+  namespace: {{namespace}}
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+ name: {{serviceAccountName}}-permission
+ namespace: {{namespace}}
+subjects:
+- kind: ServiceAccount
+  name: {{serviceAccountName}}
+  namespace: {{namespace}}
+roleRef:
+ kind: ClusterRole
+ name: admin
+ apiGroup: rbac.authorization.k8s.io

--- a/packages/helmengine/package.json
+++ b/packages/helmengine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@provisioner/helmengine",
-  "version": "0.0.4",
+  "version": "0.0.1",
   "description": "CodeZero provisioner for HelmEngine",
   "main": "lib/index.js",
   "scripts": {
@@ -19,7 +19,7 @@
   },
   "files": [
     "lib",
-    "c6o"
+    "k8s"
   ],
   "publishConfig": {
     "access": "public"
@@ -27,9 +27,11 @@
   "keywords": [
     "codezero",
     "provisioner",
-    "appengine"
+    "appengine",
+    "helm",
+    "helmengine"
   ],
-  "author": "Rob Chartier",
+  "author": "Connery Noble",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/c6o/provisioners/issues"

--- a/packages/helmengine/package.json
+++ b/packages/helmengine/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@provisioner/helmengine",
+  "version": "0.0.4",
+  "description": "CodeZero provisioner for HelmEngine",
+  "main": "lib/index.js",
+  "scripts": {
+    "bundle-develop": "parcel serve ./src/ui/index.ts --no-cache --out-dir ./lib/ui",
+    "bundle": "parcel build ./src/ui/index.ts --no-cache --out-dir ./lib/ui",
+    "build": "tsc -b && yarn run bundle",
+    "develop": "tsc -b -w --preserveWatchOutput",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "browserslist": [
+    "last 1 chrome version"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/c6o/provisioners.git"
+  },
+  "files": [
+    "lib",
+    "c6o"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "codezero",
+    "provisioner",
+    "appengine"
+  ],
+  "author": "Rob Chartier",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/c6o/provisioners/issues"
+  },
+  "homepage": "https://github.com/c6o/provisioners#readme",
+  "dependencies": {
+    "@c6o/kubeclient": "^0.0.8",
+    "@c6o/kubeclient-contracts": "^0.0.8",
+    "@provisioner/appengine": "^0.0.27",
+    "@provisioner/appengine-contracts": "^0.0.27",
+    "@provisioner/common": "^0.0.27",
+    "@provisioner/contracts": "^0.0.27",
+    "chalk": "^4.1.0",
+    "debug": "^4.2.0",
+    "generate-password": "^1.5.1",
+    "js-yaml": "^4.0.0",
+    "lit-element": "^2.3.1",
+    "lodash": "^4.17.20",
+    "mixwith": "^0.1.1",
+    "parcel-bundler": "^1.12.4",
+    "tslib": "^1.11.1"
+  },
+  "gitHead": "d24a33960e0efd45fd795d1c34112fe8174fa19c"
+}

--- a/packages/helmengine/readme.md
+++ b/packages/helmengine/readme.md
@@ -1,5 +1,5 @@
 AppEngine
 ========
 
-An automation Engine for onboarding Docker Containers onto Kubernetes written by the team @ CodeZero
+An automation Engine for onboarding Helm Charts into a CodeZero Kubernetes Cluster
 

--- a/packages/helmengine/readme.md
+++ b/packages/helmengine/readme.md
@@ -1,0 +1,5 @@
+AppEngine
+========
+
+An automation Engine for onboarding Docker Containers onto Kubernetes written by the team @ CodeZero
+

--- a/packages/helmengine/src/Dockerfile
+++ b/packages/helmengine/src/Dockerfile
@@ -1,0 +1,14 @@
+# Requires access to kubectl and helm commands.
+FROM dtzar/helm-kubectl
+
+# Set Kustomize version
+ENV KUSTOMIZE_VERSION=3.8.1
+
+# Download and install kustomize script, required for post-renderer.
+RUN curl -sLf https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz -o kustomize.tar.gz\
+    && tar xf kustomize.tar.gz \
+    && mv kustomize /usr/local/bin \
+    && chmod +x /usr/local/bin/kustomize \
+    && rm -rf ./*
+
+CMD bash

--- a/packages/helmengine/src/Dockerfile
+++ b/packages/helmengine/src/Dockerfile
@@ -4,7 +4,7 @@ FROM dtzar/helm-kubectl
 # Set Kustomize version
 ENV KUSTOMIZE_VERSION=3.8.1
 
-# Download and install kustomize script, required for post-renderer.
+# Download and install kustomize cli, required for post-renderer.
 RUN curl -sLf https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz -o kustomize.tar.gz\
     && tar xf kustomize.tar.gz \
     && mv kustomize /usr/local/bin \

--- a/packages/helmengine/src/index.ts
+++ b/packages/helmengine/src/index.ts
@@ -1,0 +1,14 @@
+import { mix } from 'mixwith'
+import { baseProvisionerType as AppEngineType, Provisioner as AppEngine } from '@provisioner/appengine'
+
+import {
+    createApplyMixin,
+    removeApplyMixin,
+} from './mixins'
+
+export type baseProvisionerType = new (...a) => Provisioner & AppEngineType
+
+export interface Provisioner extends AppEngine { }
+
+export class Provisioner extends mix(AppEngine).with(createApplyMixin, removeApplyMixin) {
+}

--- a/packages/helmengine/src/mixins/createApply.ts
+++ b/packages/helmengine/src/mixins/createApply.ts
@@ -1,0 +1,356 @@
+import { keyValue, KubeDocument } from '@c6o/kubeclient-contracts'
+import { baseProvisionerType } from '../index'
+import createDebug from 'debug'
+import * as templates from '../templates/'
+import { set as setByPath } from 'lodash'
+
+const debug = createDebug('@helmengine:createApply')
+
+declare module '../' {
+    export interface Provisioner {
+        createDeploymentDocument: KubeDocument
+    }
+}
+
+export const createApplyMixin = (base: baseProvisionerType) => class extends base {
+    async createApply() {
+        try {
+            this.manager.status?.push(`Applying Helm Engine to ${this.documentHelper.name}`)
+
+            this.job = templates.getJobTemplate(this.documentHelper.name, this.documentHelper.namespace);
+            
+            // From parent AppEngine
+            await this.processTemplates();
+
+            await this.setupJobCommand();
+            await this.applyServiceAccount();
+            await this.applyValuesConfig();
+            await this.applySecretValuesConfig();
+
+            await this.applyPostRenderConfig();
+            await this.applyJob();
+            
+            await this.ensureJobFinished();
+        }
+        finally {
+            this.manager.status?.pop()
+        }
+    }
+
+    /**
+     * Create Job resource with base Helm install command.
+     */
+    async setupJobCommand() {
+        const { name, namespace } = this.documentHelper;
+        const { chart, repo } = this.documentHelper.spec.provisioner;
+
+        this.job.spec.template.spec.containers[0].command = [
+            "helm", "install", name, chart,
+            "--namespace", namespace,
+            "--repo", repo
+        ]
+    }
+
+    /**
+     * Save provisioner configs parameters to mountable "values.yaml"
+     * and apply to helm CLI.
+     */
+    async applyValuesConfig() {
+        const { namespace, name, configs } = this.documentHelper;
+
+        if(!configs)
+            return;
+
+        try {
+            this.manager.status?.push('Installing configuration values')
+
+            const createValuesConfig = await templates.getValuesTemplate(
+                name,
+                namespace,
+                this.expandConfigs(configs) as keyValue
+            )
+
+            // Create values config file
+            await this.manager.cluster
+                .begin()
+                .addOwner(this.manager.document)
+                .mergeWith(this.documentHelper.appComponentMergeDocument)
+                .upsert(createValuesConfig)
+                .end()
+
+
+            // Add volume mount based on config values
+            const volumeName = `${name}-values`
+            const volumePath = "/opt/config"
+            const template = this.job.spec.template.spec;
+            template.volumes.push({
+                name: volumeName,
+                configMap: {
+                    name: createValuesConfig.metadata.name,
+                },
+            })
+
+            // Load mounted values
+            const container = template.containers[0];
+            container.volumeMounts.push({
+                name: volumeName,
+                mountPath: volumePath,
+                readOnly: true,
+            })
+
+            // Add values to command.
+            container.command.push("-f")
+            container.command.push(`${volumePath}/values.yaml`)
+        }
+        finally {
+            this.manager.status?.pop()
+        }
+    }
+
+    /**
+     * Save provisioner secrets parameters to mountable "values.yaml"
+     * and apply to helm CLI.
+     */
+    async applySecretValuesConfig() {
+        const { namespace, name, secrets } = this.documentHelper;
+
+        if (!secrets)
+            return;
+
+        try {
+            this.manager.status?.push('Installing secret configuration values')
+
+            const createSecretValues = templates.getSecretValuesTemplate(
+                name,
+                namespace,
+                this.expandConfigs(secrets) as keyValue
+            )
+
+            // Create values config file
+            await this.manager.cluster
+                .begin()
+                .addOwner(this.manager.document)
+                .mergeWith(this.documentHelper.appComponentMergeDocument)
+                .upsert(createSecretValues)
+                .end()
+
+            // Add volume mount based on config values
+            const volumeName = `${name}-secret-values`
+            const volumePath = "/opt/configs/secrets"
+            const template = this.job.spec.template.spec;
+            template.volumes.push({
+                name: volumeName,
+                secret: {
+                    secretName: createSecretValues.metadata.name,
+                },
+            })
+
+            // Load mounted values
+            const container = template.containers[0];
+            container.volumeMounts.push({
+                name: volumeName,
+                mountPath: volumePath,
+                readOnly: true,
+            })
+
+            // Add values to command.
+            container.command.push("-f")
+            container.command.push(`${volumePath}/values.yaml`)
+        }
+        finally {
+            this.manager.status?.pop()
+        }
+    }
+
+    /**
+     * Apply Job to the cluster.  This will schedule the helm command to execute.
+     */
+    async applyJob() {
+        try {
+            this.manager.status?.push('Creating Helm Installation Job')
+
+            await this.manager.cluster
+                .begin()
+                .addOwner(this.manager.document)
+                .mergeWith(this.documentHelper.appComponentMergeDocument)
+                .upsert(this.job)
+                .end()
+        }
+        finally {
+            this.manager.status?.pop()
+        }
+    }
+
+    /**
+     * Monitor Job progress, wait till completed.
+     * 
+     * NOTE: this does not mean the service is Ready.
+     * TODO: we should add startupProbs to handle this properly.
+     */
+    async ensureJobFinished() {
+        let jobStatus = null;
+
+        await this.manager.cluster.
+            begin(`Ensure ${this.documentHelper.name} installation finishes`)
+            .beginWatch({
+                kind: 'Pod',
+                metadata: {
+                    namespace: this.job.metadata.namespace,
+                    labels: {
+                        ['job-name']: this.job.metadata.name
+                    }
+                },
+            })
+            .whenWatch(() => true, (processor, {status: { phase }}) => {
+                jobStatus = phase
+
+                switch (phase) {
+                    case 'Succeeded':
+                        processor.endWatch()
+                        return
+                    case 'Failed':
+                        this.manager.status.error(new Error("Install Job Failed"))
+                        processor.endWatch()
+                        return
+                    default:
+                        this.manager.status.info(phase)
+                        return
+                }
+            })
+            .end()
+
+        if (jobStatus === 'Failed') {
+            throw new Error("Installation Job Failed")
+        }
+    }
+
+    /**
+     * Helm runs a post-render script to apply commonLabels and set ownerDocument
+     * This function create the kustomize script and configuration.
+     */
+     async applyPostRenderConfig() {
+        const { namespace, name, componentLabels } = this.documentHelper;
+
+        try {
+            this.manager.status?.push('Installing Post Render Processor')
+
+            const createKustomizationConfigs = await templates.getKustomizationConfigs(
+                name,
+                namespace,
+                componentLabels,
+                this.manager.document
+            )
+
+            // Create values config file
+            await this.manager.cluster
+                .begin()
+                .addOwner(this.manager.document)
+                .mergeWith(this.documentHelper.appComponentMergeDocument)
+                .upsert(createKustomizationConfigs)
+                .end()
+
+
+            // Add volume mount based on config values
+            const volumeName = `${name}-kustomize`
+            const volumePath = "/opt/kustomize"
+            const template = this.job.spec.template.spec;
+            template.volumes.push({
+                name: volumeName,
+                configMap: {
+                    name: createKustomizationConfigs.metadata.name,
+                    items: [
+                        { 
+                            key: 'postrender.sh',
+                            path: 'postrender.sh',
+                            mode: 365 // This is chmod 555, makes it executable
+                        },
+                        { 
+                            key: 'kustomization.yaml', 
+                            path: 'kustomization.yaml'
+                        },
+                    ]
+                },
+            })
+
+            // mount post-render configurations
+            const container = template.containers[0];
+            container.volumeMounts.push({
+                name: volumeName,
+                mountPath: volumePath,
+            })
+
+            // Add --post-renderer to helm command line args.
+            container.command.push("--post-renderer")
+            container.command.push(`${volumePath}/postrender.sh`)
+        }
+        finally {
+            this.manager.status?.pop()
+        }
+    }
+
+    
+    async applyServiceAccount() {
+        const { namespace, name } = this.documentHelper;
+        const serviceAccountName = `${name}-helm-installer`
+
+        try {
+            this.manager.status?.push('Setting up installer service account')
+
+            const clusterAdmin = this.documentHelper.spec.provisioner.clusterAdmin
+            const accountFile = clusterAdmin ? 'clusterServiceAccount.yaml' : 'serviceAccount.yaml'
+            await this.manager.cluster
+                .begin()
+                .addOwner(this.manager.document)
+                .mergeWith(this.documentHelper.appComponentMergeDocument)
+                .upsertFile(`../../k8s/${accountFile}`, { namespace, name, serviceAccountName })
+                .end()
+
+            // Setup service account for job
+            this.job.spec.template.spec.serviceAccountName = serviceAccountName
+
+        }
+        finally {
+            this.manager.status?.pop()
+        }
+    }
+
+    // Same as AppEngine process templates
+    async processTemplates() {
+        try {
+            this.manager.status?.push('Processing templates')
+
+            // Handles several special case config options, like "$PUBLIC_FQDN"
+            await this.processTemplate(this.documentHelper.configs, 'Processing configs templates')
+            await this.processTemplate(this.documentHelper.secrets, 'Processing secrets templates')
+        }
+        finally {
+            this.manager.status?.pop()
+        }
+    }
+
+    /**
+     * Expand configuration key names to be object paths.
+     * 
+     * For example:
+     *  foo:bar: dummyval
+     *  becomes
+     *    foo:
+     *      bar: dummyval
+     * 
+     * @param configs
+     * @returns 
+     */
+    expandConfigs(configs) {
+        const regex = /[:\.\[]/
+        for(const key of Object.keys(configs)) {
+            if (key.match(regex)) {
+                const value = configs[key]
+                delete configs[key]
+
+                setByPath(configs, key.replace(':','.'), value)
+            }
+        }
+        
+        return configs
+    }
+}

--- a/packages/helmengine/src/mixins/createApply.ts
+++ b/packages/helmengine/src/mixins/createApply.ts
@@ -261,7 +261,7 @@ export const createApplyMixin = (base: baseProvisionerType) => class extends bas
                         { 
                             key: 'postrender.sh',
                             path: 'postrender.sh',
-                            mode: 365, // This is chmod 555, makes file executable
+                            mode: 365, // This chmod makes the file executable
                         },
                         { 
                             key: 'kustomization.yaml', 

--- a/packages/helmengine/src/mixins/index.ts
+++ b/packages/helmengine/src/mixins/index.ts
@@ -1,0 +1,2 @@
+export * from './createApply'
+export * from './removeApply'

--- a/packages/helmengine/src/mixins/removeApply.ts
+++ b/packages/helmengine/src/mixins/removeApply.ts
@@ -19,11 +19,11 @@ export const removeApplyMixin = (base: baseProvisionerType) => class extends bas
     }
 
     async setupUninstallJobCommand() {
-        const { name, namespace } = this.documentHelper;
+        const { name, namespace } = this.documentHelper
 
         this.job.spec.template.spec.containers[0].command = [
             "helm", "uninstall", name,
-            "--namespace", namespace
+            "--namespace", namespace,
         ]
     }
 

--- a/packages/helmengine/src/mixins/removeApply.ts
+++ b/packages/helmengine/src/mixins/removeApply.ts
@@ -1,0 +1,60 @@
+import { baseProvisionerType } from '../'
+import * as templates from '../templates/'
+
+/**
+ * Perform Helm uninstall command.
+ * 
+ * @param base
+ * @returns 
+ */
+export const removeApplyMixin = (base: baseProvisionerType) => class extends base {
+    async removeApply() {
+        this.job = templates.getJobTemplate(this.documentHelper.name, this.documentHelper.namespace, "uninstall")
+        await this.setupUninstallJobCommand()
+
+        await this.applyUninstallJob()
+
+        // TODO: ensureUninstall has not been verified to work yet.
+        //await this.ensureUninstallJobFinished()
+    }
+
+    async setupUninstallJobCommand() {
+        const { name, namespace } = this.documentHelper;
+
+        this.job.spec.template.spec.containers[0].command = [
+            "helm", "uninstall", name,
+            "--namespace", namespace
+        ]
+    }
+
+    async applyUninstallJob() {
+        try {
+            this.manager.status?.push('Creating Helm Installation Job')
+
+            await this.manager.cluster
+                .begin()
+                .addOwner(this.manager.document)
+                .mergeWith(this.documentHelper.appComponentMergeDocument)
+                .upsert(this.job)
+                .end()
+        }
+        finally {
+            this.manager.status?.pop()
+        }
+    }
+
+    async ensureUninstallJobFinished() {
+        await this.manager.cluster.
+            begin(`Ensure ${this.documentHelper.name} uninstall finishes`)
+            .beginWatch({
+                apiVersion: this.job.apiVersion,
+                kind: this.job.kind,
+                metadata: {
+                    name: this.job.metadata.name,
+                    namespace: this.job.metadata.namespace,
+                },
+            })
+            .whenWatch(({condition}) => condition.Complete === 'True', processor => processor.endWatch())
+            .end()
+    }
+}

--- a/packages/helmengine/src/templates/index.ts
+++ b/packages/helmengine/src/templates/index.ts
@@ -1,0 +1,4 @@
+export * from './values'
+export * from './secretValues'
+export * from './job'
+export * from './kustomizeConfig'

--- a/packages/helmengine/src/templates/job.ts
+++ b/packages/helmengine/src/templates/job.ts
@@ -1,0 +1,29 @@
+
+/**
+ * Creates a base Job template to handle the installation.
+ */
+export function getJobTemplate(name: string, namespace: string, action = "install") {
+    return {
+        apiVersion: 'batch/v1',
+        kind: 'Job',
+        metadata: {
+            name: `${name}-${action}`,
+            namespace: namespace
+        },
+        spec: {
+            backoffLimit: 1, // Only try once. To allow multiple retries, must change ensureJobFinished
+            template: {
+                spec: {
+                    restartPolicy: "Never",
+                    containers: [{
+                        name: `helm-${action}`,
+                        image: "conneryn/helmengine",  // TODO: change to @c6o image
+                        command: [],
+                        volumeMounts: []
+                    }],
+                    volumes: []
+                }
+            }
+        }
+    }
+}

--- a/packages/helmengine/src/templates/kustomizeConfig.ts
+++ b/packages/helmengine/src/templates/kustomizeConfig.ts
@@ -1,6 +1,6 @@
 import { keyValue, KubeDocument } from '@c6o/kubeclient-contracts'
 import yaml from 'js-yaml'
-import { AppDocumentLabels } from '@provisioner/contracts';
+import { AppDocumentLabels } from '@provisioner/contracts'
 
 /**
  * Create JSON Patch commands to add system.codezero.io labels
@@ -19,7 +19,7 @@ const generateLabelsPatch = (path, labels) => {
         .map(k => ({
             op: "add",
             path: `${path}/${k.replace('/', '~1')}`,
-            value: labels[k]
+            value: labels[k],
         }))
 }
 
@@ -57,8 +57,8 @@ export async function getKustomizationConfigs(name: string, namespace: string, l
                 kind: owner.kind,
                 name: owner.metadata.name,
                 uid: owner.metadata.uid,
-                blockOwnerDeletion: true
-            }]
+                blockOwnerDeletion: true,
+            }],
         },
     ]
 
@@ -69,11 +69,11 @@ export async function getKustomizationConfigs(name: string, namespace: string, l
             { patch: yaml.dump(patchOwner), target: { namespace } },
             { 
                 patch: yaml.dump(generateLabelsPatch('/spec/template/metadata/labels', labels)), 
-                target: { namespace, kind: "Deployment" } 
+                target: { namespace, kind: "Deployment" },
             },
             { 
                 patch: yaml.dump(generateLabelsPatch('/metadata/labels', labels)), 
-                target: { namespace, labelSelector: `app.kubernetes.io/instance=${name}` }
+                target: { namespace, labelSelector: `app.kubernetes.io/instance=${name}` },
             },
         ],
     }
@@ -89,6 +89,6 @@ export async function getKustomizationConfigs(name: string, namespace: string, l
         data: {
             'postrender.sh': postRender,
             'kustomization.yaml': yaml.dump(kustomization),
-        }
+        },
     }
 }

--- a/packages/helmengine/src/templates/kustomizeConfig.ts
+++ b/packages/helmengine/src/templates/kustomizeConfig.ts
@@ -1,0 +1,94 @@
+import { keyValue, KubeDocument } from '@c6o/kubeclient-contracts'
+import yaml from 'js-yaml'
+import { AppDocumentLabels } from '@provisioner/contracts';
+
+/**
+ * Create JSON Patch commands to add system.codezero.io labels
+ * at specific path.
+ * 
+ * @see http://jsonpatch.com/ for more details.
+ * 
+ * @param path
+ * @param labels 
+ * @returns 
+ */
+const generateLabelsPatch = (path, labels) => {
+    return Object.keys(labels)
+        .filter(k => labels[k]) // Ensure a value exists.
+        .filter(k => k.startsWith('system.codezero.io')) // Only add system.codezero.io labels
+        .map(k => ({
+            op: "add",
+            path: `${path}/${k.replace('/', '~1')}`,
+            value: labels[k]
+        }))
+}
+
+/**
+ * Generates a ConfigMap that contains a Kusomization script used by post-rendered to update all 
+ * Helm generated resources.
+ * 
+ * This ConfigMap should be mounted into the helm job, and executed as a post-renderer script.
+ * 
+ * Adds:
+ *  - system.codezero.io lables
+ *  - ownerReferences to the App Resource.
+ * 
+ * @param name
+ * @param namespace 
+ * @param labels 
+ * @param owner 
+ * @returns 
+ */
+export async function getKustomizationConfigs(name: string, namespace: string, labels: AppDocumentLabels, owner: KubeDocument) {
+    // Shell script to run kustomize script.
+    const postRender = [
+        "#!/bin/sh",
+        "cat > input.yaml",                            // Save incoming data as file.
+        `cp $(dirname "$0")/kustomization.yaml ./`,    // Copy kustomization scripts to cwd
+        "exec kustomize build",                        // Execute kustomize
+    ].join("\n")
+
+    const patchOwner = [
+        {
+            op: "add",
+            path: "/metadata/ownerReferences",
+            value: [{
+                apiVersion: owner.apiVersion,
+                kind: owner.kind,
+                name: owner.metadata.name,
+                uid: owner.metadata.uid,
+                blockOwnerDeletion: true
+            }]
+        },
+    ]
+
+    // Applies commonLabels to metadata, and template metadata.
+    const kustomization = {
+        resources: ['input.yaml'],
+        patches: [
+            { patch: yaml.dump(patchOwner), target: { namespace } },
+            { 
+                patch: yaml.dump(generateLabelsPatch('/spec/template/metadata/labels', labels)), 
+                target: { namespace, kind: "Deployment" } 
+            },
+            { 
+                patch: yaml.dump(generateLabelsPatch('/metadata/labels', labels)), 
+                target: { namespace, labelSelector: `app.kubernetes.io/instance=${name}` }
+            },
+        ],
+    }
+
+    // Creates mountable postrender.sh script, and kustomize configs.
+    return {
+        apiVersion: 'v1',
+        kind: 'ConfigMap',
+        metadata: {
+            name: `${name}-kustomization`,
+            namespace: namespace,
+        },
+        data: {
+            'postrender.sh': postRender,
+            'kustomization.yaml': yaml.dump(kustomization),
+        }
+    }
+}

--- a/packages/helmengine/src/templates/secretValues.ts
+++ b/packages/helmengine/src/templates/secretValues.ts
@@ -1,0 +1,18 @@
+import { keyValue } from '@c6o/kubeclient-contracts'
+import yaml from 'js-yaml'
+
+export function getSecretValuesTemplate(name: string, namespace: string, data: keyValue) {
+    const values = yaml.dump(data)
+
+    return {
+        apiVersion: 'v1',
+        kind: 'Secret',
+        metadata: {
+            name: `${name}-secret-values`,
+            namespace: namespace
+        },
+        data: {
+            'values.yaml': Buffer.from(values).toString('base64')
+        }
+    }
+}

--- a/packages/helmengine/src/templates/secretValues.ts
+++ b/packages/helmengine/src/templates/secretValues.ts
@@ -1,7 +1,6 @@
-import { keyValue } from '@c6o/kubeclient-contracts'
 import yaml from 'js-yaml'
 
-export function getSecretValuesTemplate(name: string, namespace: string, data: keyValue) {
+export function getSecretValuesTemplate(name: string, namespace: string, data: any) {
     const values = yaml.dump(data)
 
     return {

--- a/packages/helmengine/src/templates/values.ts
+++ b/packages/helmengine/src/templates/values.ts
@@ -1,7 +1,6 @@
-import { keyValue } from '@c6o/kubeclient-contracts'
 import yaml from 'js-yaml'
 
-export async function getValuesTemplate(name: string, namespace: string, data: keyValue) {
+export async function getValuesTemplate(name: string, namespace: string, data: any) {
     let values = yaml.dump(data)
 
     return {

--- a/packages/helmengine/src/templates/values.ts
+++ b/packages/helmengine/src/templates/values.ts
@@ -1,0 +1,18 @@
+import { keyValue } from '@c6o/kubeclient-contracts'
+import yaml from 'js-yaml'
+
+export async function getValuesTemplate(name: string, namespace: string, data: keyValue) {
+    let values = yaml.dump(data)
+
+    return {
+        apiVersion: 'v1',
+        kind: 'ConfigMap',
+        metadata: {
+            name: `${name}-values`,
+            namespace: namespace
+        },
+        data: {
+            'values.yaml': values
+        }
+    }
+}

--- a/packages/helmengine/src/ui/index.ts
+++ b/packages/helmengine/src/ui/index.ts
@@ -1,0 +1,16 @@
+import { AppEngineSettings } from '@provisioner/appengine/lib/ui'
+
+export class HelmInstall extends AppEngineSettings {
+
+    // TODO: I don't know how to make this work....?
+    async test() {
+        await this.manager.cluster
+            .begin('Install Grafana services')
+                .addOwner(this.manager.document)
+                .upsertFile('../../k8s/pvc.yaml', { namespace, storage, storageClass })
+                .upsertFile('../../k8s/deployment.yaml', { namespace, adminUsername, adminPassword })
+                .upsertFile('../../k8s/service.yaml', { namespace })
+            .end()
+    }
+
+}

--- a/packages/helmengine/src/ui/index.ts
+++ b/packages/helmengine/src/ui/index.ts
@@ -1,16 +1,12 @@
 import { AppEngineSettings } from '@provisioner/appengine/lib/ui'
+import { LitElement, customElement } from 'lit-element'
 
+export interface HelmInstall extends LitElement {
+
+}
+
+
+@customElement('helmengine-install-main')
 export class HelmInstall extends AppEngineSettings {
-
-    // TODO: I don't know how to make this work....?
-    async test() {
-        await this.manager.cluster
-            .begin('Install Grafana services')
-                .addOwner(this.manager.document)
-                .upsertFile('../../k8s/pvc.yaml', { namespace, storage, storageClass })
-                .upsertFile('../../k8s/deployment.yaml', { namespace, adminUsername, adminPassword })
-                .upsertFile('../../k8s/service.yaml', { namespace })
-            .end()
-    }
 
 }

--- a/packages/helmengine/src/ui/tsconfig.json
+++ b/packages/helmengine/src/ui/tsconfig.json
@@ -1,0 +1,28 @@
+// Extends is not supported at this time by parcel-cli
+{
+    "compilerOptions": {
+        "composite": true,
+        "module": "esnext",
+        "moduleResolution": "node",
+        "declaration": true,
+        "noImplicitAny": false,
+        "removeComments": true,
+        "noLib": false,
+        "outDir": "./lib",
+        "rootDir": "../",
+        "emitDecoratorMetadata": true,
+        "experimentalDecorators": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "target": "es2018",
+        "sourceMap": true,
+        "lib": [
+            "es2018",
+            "dom"
+        ],
+    },
+    "references": [
+        { "path": "../../../common" },
+        { "path": "../../../appengine" }
+    ]
+}

--- a/packages/helmengine/tsconfig.json
+++ b/packages/helmengine/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "rootDir": "./src",
+        "outDir": "./lib"
+    },
+    "references": [
+        { "path":  "../common" },
+        { "path":  "../contracts" },
+        { "path":  "../appengine-contracts" }
+    ],
+    "include": [
+        "./src"
+    ],
+    "exclude": [
+        "src/ui",
+        "test",
+        "**/*.unit.ts",
+        "node_modules"
+    ]
+}


### PR DESCRIPTION
## Description

Introduces the HelmEngine application provisioned.  An application developer can leverage the Flow and configuration stages of AppEngine, but then use an existing Helm Chart to perform the actual installation logic.

Fixes #225 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## How Has This Been Tested?

WARN: This has been tested using the CLI only.  The WebUI currently does not work.

## Remaining items to do

- [ ] Setup UI components so this works in the web UI.
- [ ] Publish `dockerfile` to docker hub  (ideally automated)
- [ ] Publish to NPM under @provisioner/helmengine (ideally automated)
- [ ] Documentation (separate story for this)
