### PR TITLE
Fix(ELK): Kibana startup probe port

### DIFF
--- a/packages/logging-elk/k8s/kibana.yaml
+++ b/packages/logging-elk/k8s/kibana.yaml
@@ -50,7 +50,7 @@ spec:
         startupProbe:
           httpGet:
             path: /
-            port: rest
+            port: 5601
           failureThreshold: 30      # When a probe fails, Kubernetes will try failureThreshold times before giving up. Giving up in case of liveness probe means restarting the container. In case of readiness probe the Pod will be marked Unready. Defaults to 3. Minimum value is 1.
           timeoutSeconds: 10        # Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
           periodSeconds: 10         # How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.


### PR DESCRIPTION
## Description
Kibana startup probe fails because the port number is incorrect.

Fixes #175 

![image](https://user-images.githubusercontent.com/4723264/112229751-cea0f900-8bf0-11eb-9a2e-45c557d4cfd0.png)

