### PR TITLE
chore: remove deamon common from client

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/nsainaney/traxitt#readme",
   "dependencies": {
+    "@c6o/kubeclient": "^0.0.13",
     "@c6o/kubeclient-contracts": "^0.0.13",
     "@provisioner/contracts": "^0.0.30",
     "debug": "^4.1.1",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -24,15 +24,13 @@
   },
   "homepage": "https://github.com/nsainaney/traxitt#readme",
   "dependencies": {
-    "@c6o/kubeclient": "^0.0.13",
     "@c6o/kubeclient-contracts": "^0.0.13",
     "@provisioner/contracts": "^0.0.30",
     "debug": "^4.1.1",
     "generate-password": "^1.6.0",
     "jsonpath-plus": "^5.0.7",
     "jsonpointer": "^4.1.0",
-    "mixwith": "^0.1.1",
-    "ulid": "^2.3.0"
+    "mixwith": "^0.1.1"
   },
   "gitHead": "76270c0e55c21dd5e02cd24c03c84567f77af028"
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -24,8 +24,8 @@
   },
   "homepage": "https://github.com/nsainaney/traxitt#readme",
   "dependencies": {
-    "@c6o/kubeclient": "^0.0.13",
     "@c6o/kubeclient-contracts": "^0.0.13",
+    "@c6o/kubeclient-helpers": "^0.0.13",
     "@provisioner/contracts": "^0.0.30",
     "debug": "^4.1.1",
     "generate-password": "^1.6.0",

--- a/packages/common/src/helpers/workload/helper.ts
+++ b/packages/common/src/helpers/workload/helper.ts
@@ -1,5 +1,5 @@
 import { JSONPath } from 'jsonpath-plus'
-import { keyValue } from '@c6o/kubeclient-contracts'
+import { WorkloadKind, WorkloadResource, keyValue } from '@c6o/kubeclient-contracts'
 import {
     pathToConfigMapRefs,
     pathToEnv,
@@ -8,7 +8,6 @@ import {
     pathToVolumeMounts,
     pathToVolumes
 } from './paths'
-import { WorkloadKind, WorkloadResource } from './types'
 import { Volume, VolumeMount } from '@c6o/kubeclient-resources/lib/core/v1'
 
 export type WorkloadOrArray = WorkloadResource | WorkloadResource[]

--- a/packages/common/src/helpers/workload/helper.ts
+++ b/packages/common/src/helpers/workload/helper.ts
@@ -1,5 +1,5 @@
 import { JSONPath } from 'jsonpath-plus'
-import { WorkloadKind, WorkloadResource } from '@c6o/kubeclient'
+import { WorkloadKind, WorkloadResource } from '@c6o/kubeclient-helpers'
 import { keyValue } from '@c6o/kubeclient-contracts'
 import {
     pathToConfigMapRefs,

--- a/packages/common/src/helpers/workload/helper.ts
+++ b/packages/common/src/helpers/workload/helper.ts
@@ -1,5 +1,6 @@
 import { JSONPath } from 'jsonpath-plus'
-import { WorkloadKind, WorkloadResource, keyValue } from '@c6o/kubeclient-contracts'
+import { WorkloadKind, WorkloadResource } from '@c6o/kubeclient'
+import { keyValue } from '@c6o/kubeclient-contracts'
 import {
     pathToConfigMapRefs,
     pathToEnv,

--- a/packages/common/src/helpers/workload/index.ts
+++ b/packages/common/src/helpers/workload/index.ts
@@ -1,3 +1,2 @@
 export * from './helper'
 export * from './paths'
-export * from './types'

--- a/packages/common/src/helpers/workload/paths.ts
+++ b/packages/common/src/helpers/workload/paths.ts
@@ -1,4 +1,4 @@
-import { WorkloadKind } from '@c6o/kubeclient'
+import { WorkloadKind } from '@c6o/kubeclient-helpers'
 
 export const pathToSpec = (kind: WorkloadKind) => {
     switch (kind) {

--- a/packages/common/src/helpers/workload/paths.ts
+++ b/packages/common/src/helpers/workload/paths.ts
@@ -1,4 +1,4 @@
-import { WorkloadKind } from './types'
+import { WorkloadKind } from '@c6o/kubeclient-contracts'
 
 export const pathToSpec = (kind: WorkloadKind) => {
     switch (kind) {

--- a/packages/common/src/helpers/workload/paths.ts
+++ b/packages/common/src/helpers/workload/paths.ts
@@ -1,4 +1,4 @@
-import { WorkloadKind } from '@c6o/kubeclient-contracts'
+import { WorkloadKind } from '@c6o/kubeclient'
 
 export const pathToSpec = (kind: WorkloadKind) => {
     switch (kind) {

--- a/packages/common/src/helpers/workload/types.ts
+++ b/packages/common/src/helpers/workload/types.ts
@@ -1,6 +1,0 @@
-import { Namespace, Pod } from '@c6o/kubeclient-resources/core/v1'
-import { Deployment, StatefulSet } from '@c6o/kubeclient-resources/apps/v1'
-import { Job, CronJob } from '@c6o/kubeclient-resources/batch/v1'
-
-export type WorkloadKind = 'Pod' | 'Deployment' | 'Job' | 'CronJob' | 'StatefulSet' | 'Namespace'
-export type WorkloadResource = Pod | Deployment | Job | CronJob | StatefulSet | Namespace

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -6,6 +6,7 @@
     },
     "references": [
         { "path": "../contracts" },
+        { "path": "../../../kubeclient/packages/client" },
         { "path": "../../../kubeclient/packages/contracts" }
     ],
     "include": [

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -6,7 +6,7 @@
     },
     "references": [
         { "path": "../contracts" },
-        { "path": "../../../kubeclient/packages/client" },
+        { "path": "../../../kubeclient/packages/helpers" },
         { "path": "../../../kubeclient/packages/contracts" }
     ],
     "include": [

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -5,7 +5,8 @@
         "outDir": "./lib"
     },
     "references": [
-        { "path":  "../contracts" }
+        { "path": "../contracts" },
+        { "path": "../../../kubeclient/packages/contracts" }
     ],
     "include": [
         "src"


### PR DESCRIPTION
## Description

Pull out KubeclientWorkload and KubeclientResources from provisioners common and put them into kubeclient-helpers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Technical improvement or removal of technical debt. 
- [ ] Minor change: comments, documentation, trivial fixes

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Unit Tests

Optional:

- [ ] Functional Tests
- [ ] Integration Tests

